### PR TITLE
Fixed #29895: Added clarification for MySQL 8 atomic DDLs in migrations howto

### DIFF
--- a/docs/howto/writing-migrations.txt
+++ b/docs/howto/writing-migrations.txt
@@ -223,6 +223,13 @@ smaller batches::
 The ``atomic`` attribute doesn't have an effect on databases that don't support
 DDL transactions (e.g. MySQL, Oracle).
 
+.. note:: 
+  The `Atomic DDL feature introduced in MySQL 8 
+  <https://dev.mysql.com/doc/refman/8.0/en/atomic-ddl.html>`_ **is not atomic in
+  this sense**, it does not refer to multiple statements wrapped in a transaction
+  that can be rolled back but to individual DDL statements, and therefore not
+  supported.
+
 Controlling the order of migrations
 ===================================
 


### PR DESCRIPTION
Added a clarification that Atomic DDLs introduced in MySQL 8 are not supported
as atomic in migrations (they are not atomic in "the sense of Django")